### PR TITLE
chore: remove infra/ from git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,6 @@
-[submodule "infra"]
-	path = eng/infra
-	url = git@github.com:ljtill/pipelines-infra.git
-	branch = main
 [submodule "config"]
 	path = eng/config
 	url = git@github.com:ljtill/pipelines-config.git
-	branch = main
-[submodule "images"]
-	path = eng/images
-	url = git@github.com:ljtill/pipelines-images.git
 	branch = main
 [submodule "tools"]
 	path = eng/tools


### PR DESCRIPTION
- Remove `infra/` from Git Submodules
- Remove orphaned objects in `.gitmodules`