### PR TITLE
chore: rename azure deployments

### DIFF
--- a/eng/platform/modules/clusters/resources.bicep
+++ b/eng/platform/modules/clusters/resources.bicep
@@ -253,7 +253,7 @@ resource storageAccountTableContributorRoleAssignment 'Microsoft.Authorization/r
 
 // Virtual Network Links
 resource links 'Microsoft.Resources/deployments@2021-04-01' = {
-  name: 'Microsoft.Bicep.Resources.Network'
+  name: 'Microsoft.Resources.Network'
   subscriptionId: services.subscription
   resourceGroup: services.resourceGroup
   properties: {
@@ -342,7 +342,7 @@ resource links 'Microsoft.Resources/deployments@2021-04-01' = {
 // Role Assignments
 // NOTE: Workaround for cross resource group role assignments
 resource authorization 'Microsoft.Resources/deployments@2021-04-01' = {
-  name: 'Microsoft.Bicep.Authorization.Services'
+  name: 'Microsoft.Authorization.Services'
   subscriptionId: services.subscription
   resourceGroup: services.resourceGroup
   properties: {
@@ -382,7 +382,7 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-12-01-pr
 // -------
 
 module diagnostics './resources.diagnostics.bicep' = {
-  name: 'Microsoft.Bicep.Resources.Diagnostics.${cluster.properties.country}'
+  name: 'Microsoft.Resources.Diagnostics.${cluster.properties.country}'
   params: {
     services: services
     cluster: cluster
@@ -398,7 +398,7 @@ module diagnostics './resources.diagnostics.bicep' = {
 }
 
 module endpoints './resources.endpoints.bicep' = {
-  name: 'Microsoft.Bicep.Resources.Endpoints.${cluster.properties.country}'
+  name: 'Microsoft.Resources.Endpoints.${cluster.properties.country}'
   params: {
     services: services
     cluster: cluster

--- a/eng/platform/modules/services/resources.bicep
+++ b/eng/platform/modules/services/resources.bicep
@@ -85,7 +85,7 @@ resource storageAccountTable 'Microsoft.Network/privateDnsZones@2020-06-01' = {
 // -------
 
 module diagnostics './resources.diagnostics.bicep' = {
-  name: 'Microsoft.Bicep.Resources.Diagnostics'
+  name: 'Microsoft.Resources.Diagnostics'
   params: {
     services: services
   }

--- a/eng/platform/region.bicep
+++ b/eng/platform/region.bicep
@@ -10,7 +10,7 @@ targetScope = 'subscription'
 
 // Groups
 module groups 'modules/groups/resources.bicep' = {
-  name: 'Microsoft.Bicep.Resources.Groups'
+  name: 'Microsoft.Resources.Groups'
   params: {
     services: config.services
     clusters: config.clusters
@@ -19,7 +19,7 @@ module groups 'modules/groups/resources.bicep' = {
 
 // Services
 module services 'modules/services/resources.bicep' = {
-  name: 'Microsoft.Bicep.Resources.Services'
+  name: 'Microsoft.Resources.Services'
   scope: resourceGroup(config.services.subscription, config.services.resourceGroup)
   params: {
     services: config.services
@@ -32,7 +32,7 @@ module services 'modules/services/resources.bicep' = {
 // Clusters
 @batchSize(1)
 module clusters 'modules/clusters/resources.bicep' = [for cluster in config.clusters: {
-  name: 'Microsoft.Bicep.Resources.Clusters.${cluster.properties.country}'
+  name: 'Microsoft.Resources.Clusters.${cluster.properties.country}'
   scope: resourceGroup(cluster.subscription, cluster.resourceGroup)
   params: {
     services: config.services

--- a/eng/scripts/platform.sh
+++ b/eng/scripts/platform.sh
@@ -15,7 +15,7 @@ environment()
     tenant_id=$(az account show -o json | jq -r '.tenantId')
     config_path="../configs/platform.local.json"
     config_data=$(cat $config_path)
-    deployment_name="Microsoft.Bicep.Resources"
+    deployment_name="Microsoft.Resources"
     location="Norway East"
     app_name="Pipelines"
 }


### PR DESCRIPTION
- Remove `Bicep` prefix from Azure Resource Manager deployment names