### PR TITLE
fix: add replace function to parse certain address prefixes

### DIFF
--- a/eng/platform/modules/services/resources.bicep
+++ b/eng/platform/modules/services/resources.bicep
@@ -20,7 +20,7 @@ resource registry 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' = 
       defaultAction: 'Deny'
       ipRules: [for ipRule in services.properties.clientAddresses: {
         action: 'Allow'
-        value: ipRule
+        value: replace(ipRule, '/32', '')
       }]
     }
   }


### PR DESCRIPTION
- Handle `/32` address prefixes on ipRules